### PR TITLE
Put a note next to '100% reproducible'

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -72,8 +72,9 @@ const IndexPage = () => (
               THE CONTAINER SYSTEM FOR SECURE HIGH PERFORMANCE COMPUTING
             </h3>
             <p className="text-base mb-10 text-gray-700 md:text-lg">
-              Apptainer/Singularity is the most widely used container system for HPC. It is designed to execute applications at bare-metal performance while being secure, portable, and 100% reproducible. Apptainer is an open-source project with a friendly community of developers and users. The user base continues to expand, with Apptainer/Singularity now used across industry and academia in many areas of work.
+              Apptainer/Singularity is the most widely used container system for HPC. It is designed to execute applications at bare-metal performance while being secure, portable, and can be configured to be 100% reproducible*. Apptainer is an open-source project with a friendly community of developers and users. The user base continues to expand, with Apptainer/Singularity now used across industry and academia in many areas of work.
             </p>
+            <p><small>*By using the --containall flag, <a href=http://apptainer.org/user-docs/master/index.html>see the documentation for more details.</a></small></p>
           </div>
 
           <div className="flex items-center sm:justify-center">


### PR DESCRIPTION
This was discussed in https://github.com/apptainer/apptainer/issues/64 .

I don't know if the * and the comment in `<small>` are well-placed on the main page. At least stating that singularity can be configured to be reproducible instead of claiming it is 100% reproducible is more accurate and it will hopefully lead people to use the `--containall` flag if 100% reproducibility is a requirement.

Alternative route:
Remove the * and the docs link and add a chapter in the documentation called `Reproducibility` that highlights the `--containall` flag. That is perhaps the preferrable route.