### PR TITLE
Remove attempt at hyperlink to EPEL

### DIFF
--- a/src/pages/getting-started.js
+++ b/src/pages/getting-started.js
@@ -27,7 +27,7 @@ const gettingStartedLinks = [
         name: 'Binary Packages',
         href: 'https://github.com/apptainer/apptainer/releases',
         description:
-            'Pre-built packages are available for download as Assets under each github release; you can also find them in <a href=https://docs.fedoraproject.org/en-US/epel/>EPEL</a> for RHEL derivatives.',
+            'Pre-built packages are available for download as Assets under each github release; you can also find them in EPEL for RHEL derivatives.',
         icon: SupportIcon,
         button: 'Releases'
     },


### PR DESCRIPTION
The attempt at a hyperlink to EPEL on the getting-started page did not work, so this removes it.