### PR TITLE
Fix duplicated link to youtube video

### DIFF
--- a/src/data/showcases.json
+++ b/src/data/showcases.json
@@ -7,7 +7,7 @@
 	},
 	{
 		"title": "Singularity: Containers for Science, Reproducibility, and HPC",
-		"link": "https://youtu.be/lZENN9LVqY8",
+		"link": "https://youtu.be/DA87Ba2dpNM",
 		"description": "This talk explores how Singularity combines software packaging models with minimalistic containers to create very lightweight application bundles.",
 		"author": "2017 HPC Advisory Council Stanford Conference"
 	},


### PR DESCRIPTION
https://apptainer.org/showcases/

The first video was duplicated, so second video is missing:

[Apptainer 1.1.0 Has Been Released](https://youtu.be/lZENN9LVqY8)
A discussion of the new features and updated security posture of the groundbreaking Apptainer 1.1.0 release.

Ctrl IQ Weekly Webinar Series

[Singularity: Containers for Science, Reproducibility, and HPC](https://youtu.be/lZENN9LVqY8)
This talk explores how Singularity combines software packaging models with minimalistic containers to create very lightweight application bundles.

2017 HPC Advisory Council Stanford Conference

You can search for the title, but...